### PR TITLE
Replace china specific DNS with general DNS

### DIFF
--- a/V2rayNG/app/src/main/kotlin/com/v2ray/ang/AppConfig.kt
+++ b/V2rayNG/app/src/main/kotlin/com/v2ray/ang/AppConfig.kt
@@ -66,7 +66,7 @@ object AppConfig {
     const val geoUrl = "https://github.com/Loyalsoldier/v2ray-rules-dat/releases/latest/download/";
 
     const val DNS_AGENT = "1.1.1.1"
-    const val DNS_DIRECT = "223.5.5.5"
+    const val DNS_DIRECT = "1.1.1.1"
 
     const val PORT_LOCAL_DNS = "10853"
     const val PORT_SOCKS = "10808"


### PR DESCRIPTION
China-specific DNS doesn't have good performance in Iran. So it is recommended to replace it with a general one.