### PR TITLE
Increase routing accuracy

### DIFF
--- a/V2rayNG/app/src/main/assets/custom_routing_direct
+++ b/V2rayNG/app/src/main/assets/custom_routing_direct
@@ -1,5 +1,5 @@
 domain:ir,
-geosite:category-ir,
+ext:geosite_c4u.dat:ir,
 geosite:private,
-geoip:ir,
+ext:geoip_c4u.dat:ir,
 geoip:private,


### PR DESCRIPTION
Geoip from chacolate4u is more complete than default geoip. default geoip only uses maxmind database. c4u geoip uses maxmind database, ip2location database, iranian CDN database and iranian IMs IPs. So c4u geoip uses all data from default geoip there will be no need to remain default geoip.

Geosite:ir from chacolate4u includes all of the category-ir list beside Bootmortis list which makes it more complete.

Reference:
https://github.com/Chocolate4U/Iran-v2ray-rules#geoip-1