### PR TITLE
Xray-core default FakeIPv6 Pool should not bypass and should route

### DIFF
--- a/V2rayNG/app/src/main/kotlin/com/v2ray/ang/service/V2RayVpnService.kt
+++ b/V2rayNG/app/src/main/kotlin/com/v2ray/ang/service/V2RayVpnService.kt
@@ -131,6 +131,7 @@ class V2RayVpnService : VpnService(), ServiceControl {
             builder.addAddress(PRIVATE_VLAN6_CLIENT, 126)
             if (routingMode == ERoutingMode.BYPASS_LAN.value || routingMode == ERoutingMode.BYPASS_LAN_MAINLAND.value) {
                 builder.addRoute("2000::", 3) //currently only 1/8 of total ipV6 is in use
+                builder.addRoute("fc00::", 18) //Xray-core default FakeIPv6 Pool
             } else {
                 builder.addRoute("::", 0)
             }


### PR DESCRIPTION
سلام
این رنج پیشفرض fakeDNS برای ipv6 تو هسته xray-core هست.
نباید بایپس بشه و باید به هسته route بشه.
https://github.com/2dust/v2rayNG/pull/4649