### PR TITLE
Add desktop bridge note to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,17 @@
 - MahsaNG is a v2rayNG client aimed to provide free vpn for everyone<br>
 <img src="https://github.com/GFW-knocker/MahsaNG/blob/master/Mahsa_logo.jpg?raw=true" width="480" ><br>
 
+# Desktop / macOS users
+
+Many MahsaNG users ask the same question after using the Android app: "Can I use these daily configs on my desktop too?"
+
+Until there is an official desktop client, you do not need to wait for a full rewrite of the app. The community project [MahsaNG macOS Bridge](https://github.com/MostafaDadkhah/MahsaNG-macOS-Bridge) focuses on the real missing piece: it turns MahsaNG / MahsaFreeConfig daily feeds into a standard local subscription that macOS proxy clients can import.
+
+If you are on macOS and want a desktop-friendly path, use this bridge:
+
+- [MahsaNG macOS Bridge](https://github.com/MostafaDadkhah/MahsaNG-macOS-Bridge)
+
+It is a small companion tool, not a replacement for MahsaNG Android. It helps desktop users keep using the same ecosystem with the tools they already have on macOS. If it helps you, consider starring the bridge so more MahsaNG desktop users can find it.
 
 # What is the idea
 - MahsaNG is client-side of project [Segaro_Dream](https://github.com/GFW-knocker/Segaro_Dream)

--- a/README.md
+++ b/README.md
@@ -5,17 +5,17 @@
 - MahsaNG is a v2rayNG client aimed to provide free vpn for everyone<br>
 <img src="https://github.com/GFW-knocker/MahsaNG/blob/master/Mahsa_logo.jpg?raw=true" width="480" ><br>
 
-# Desktop / macOS users
+# Desktop users (macOS, Linux, Windows)
 
 Many MahsaNG users ask the same question after using the Android app: "Can I use these daily configs on my desktop too?"
 
-Until there is an official desktop client, you do not need to wait for a full rewrite of the app. The community project [MahsaNG macOS Bridge](https://github.com/MostafaDadkhah/MahsaNG-macOS-Bridge) focuses on the real missing piece: it turns MahsaNG / MahsaFreeConfig daily feeds into a standard local subscription that macOS proxy clients can import.
+Until there is an official desktop client, you do not need to wait for a full rewrite of the app. The community project [MahsaNG Desktop Bridge](https://github.com/MostafaDadkhah/MahsaNG-Desktop-Bridge) focuses on the real missing piece: it turns MahsaNG / MahsaFreeConfig daily feeds into a standard local subscription that desktop proxy clients can import.
 
-If you are on macOS and want a desktop-friendly path, use this bridge:
+If you are on macOS, Linux, or Windows and want a desktop-friendly path, use this bridge:
 
-- [MahsaNG macOS Bridge](https://github.com/MostafaDadkhah/MahsaNG-macOS-Bridge)
+- [MahsaNG Desktop Bridge](https://github.com/MostafaDadkhah/MahsaNG-Desktop-Bridge)
 
-It is a small companion tool, not a replacement for MahsaNG Android. It helps desktop users keep using the same ecosystem with the tools they already have on macOS. If it helps you, consider starring the bridge so more MahsaNG desktop users can find it.
+It is a small companion tool, not a replacement for MahsaNG Android. It helps desktop users keep using the same ecosystem with the tools they already have. If it helps you, consider starring the bridge so more MahsaNG desktop users can find it.
 
 # What is the idea
 - MahsaNG is client-side of project [Segaro_Dream](https://github.com/GFW-knocker/Segaro_Dream)


### PR DESCRIPTION
Many MahsaNG users ask for a desktop path after using the Android app.

This PR adds a short README section that points macOS, Linux, and Windows users to the community MahsaNG Desktop Bridge project:

https://github.com/MostafaDadkhah/MahsaNG-Desktop-Bridge

The wording keeps it clear that the bridge is a companion tool, not an official replacement for the Android app. It focuses on helping desktop users discover a practical path without turning the upstream README into endpoint-level technical docs.